### PR TITLE
Preprocess without Verilator

### DIFF
--- a/src/main/resources/vsrc/Makefile
+++ b/src/main/resources/vsrc/Makefile
@@ -126,37 +126,25 @@ lookup_dirs = $(shell find -L $(ariane_dir) -name target -prune -o -type d -prin
 INC_DIR_NAMES ?= include inc
 INC_DIRS ?= $(foreach dir_name,$(INC_DIR_NAMES),$(call lookup_dirs,$(dir_name)))
 
-# default ariane top module
-TOP = ArianeCoreBlackbox
-
 # these flags are specific to Chipyard
-EXTRA_PREPROC_OPTS ?=
+EXTRA_PREPROC_DEFINES ?=
 PREPROC_DEFINES ?= \
-	+define+WT_DCACHE \
-	+define+DISABLE_TRACER \
-	+define+SRAM_NO_INIT
+	WT_DCACHE \
+	DISABLE_TRACER \
+	SRAM_NO_INIT \
+	$(EXTRA_PREPROC_DEFINES)
 
-PREPROC_VERILATOR_OPTS = \
-	-E \
-	$(foreach dir_path,$(INC_DIRS),+incdir+$(dir_path)) \
-	-Wno-STMTDLY \
-	-Werror-IMPLICIT \
-	-Wno-ASSIGNDLY \
-	-Wno-UNOPTFLAT \
-	-Wno-BLKANDNBLK \
-	-Wall \
-	$(OTHER_PREPROC_VERILATOR_OPTS) \
-	$(PREPROC_DEFINES) \
-	$(EXTRA_PREPROC_OPTS)
+PREPROC_SCRIPT = $(base_dir)/scripts/insert-includes.py
 
-# THIS IS ARIANE SPECIFIC
-# - Preprocess with Verilator but convert the pragmas into ifdefs
 $(PREPROC_VERILOG): $(ALL_VSRCS)
-	cat $(ALL_VSRCS) > combined.sv
-	awk '{ if (/pragma translate_off/) { print "`ifdef ETHZ" } else if (/pragma translate_on/) { print "`endif" } else { print } }' > combined.nopragma.sv < combined.sv
-	verilator --cc --exe $(PREPROC_VERILATOR_OPTS) combined.nopragma.sv -Mdir $(vsrc_dir)/$(long_name).preprocess --top-module $(TOP) > $@
-	sed -i '/^`line/d' $@
-	rm -rf combined.nopragma.sv combined.sv $(vsrc_dir)/$(long_name).preprocess
+	mkdir -p $(dir $(PREPROC_VERILOG))
+	$(foreach def,$(PREPROC_DEFINES),echo "\`define $(def)" >> def.v; )
+	$(foreach def,$(PREPROC_DEFINES),echo "\`undef $(def)" >> undef.v; )
+	cat def.v $(ALL_VSRCS) undef.v > combined.sv
+	sed -i '/l15.tmp.h/d' combined.sv
+	sed -i '/define.tmp.h/d' combined.sv
+	$(PREPROC_SCRIPT) combined.sv $@ $(INC_DIRS)
+	rm -rf combined.sv def.v undef.v
 
 clean:
 	rm -rf $(PREPROC_VERILOG)

--- a/src/main/resources/vsrc/Makefile
+++ b/src/main/resources/vsrc/Makefile
@@ -132,6 +132,7 @@ PREPROC_DEFINES ?= \
 	WT_DCACHE \
 	DISABLE_TRACER \
 	SRAM_NO_INIT \
+	VERILATOR \
 	$(EXTRA_PREPROC_DEFINES)
 
 PREPROC_SCRIPT = $(base_dir)/scripts/insert-includes.py

--- a/src/main/scala/ArianeCoreBlackbox.scala
+++ b/src/main/scala/ArianeCoreBlackbox.scala
@@ -140,7 +140,7 @@ class ArianeCoreBlackbox(
 
   // pre-process the verilog to remove "includes" and combine into one file
   val make = "make -C generators/ariane/src/main/resources/vsrc default "
-  val proc = if (traceportEnabled) make + "EXTRA_PREPROC_OPTS=+define+FIRESIM_TRACE" else make
+  val proc = if (traceportEnabled) make + "EXTRA_PREPROC_DEFINES=FIRESIM_TRACE" else make
   require (proc.! == 0, "Failed to run preprocessing step")
 
   // add wrapper/blackbox after it is pre-processed


### PR DESCRIPTION
Corresponds with https://github.com/ucb-bar/chipyard/pull/505

Changes the `Makefile` that combines all the Verilog files to use a `insert-includes.py` in Chipyard to pre-process/replace out the `.vh` files.