### PR TITLE
remove objectmodule

### DIFF
--- a/src/main/scala/CVA6CoreBlackbox.scala
+++ b/src/main/scala/CVA6CoreBlackbox.scala
@@ -23,7 +23,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree, LogicalTreeNode, RocketLogicalTreeNode, ICacheLogicalTreeNode}
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/CVA6Tile.scala
+++ b/src/main/scala/CVA6Tile.scala
@@ -21,7 +21,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode}
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._


### PR DESCRIPTION
This is needed for RC bumping after chipsalliance/rocket-chip#2967 get merged. 